### PR TITLE
Marsellus

### DIFF
--- a/kernel/chips/marsellus/link.ld
+++ b/kernel/chips/marsellus/link.ld
@@ -3,8 +3,8 @@ OUTPUT_ARCH(riscv)
 ENTRY( _start )
 MEMORY
 {
-  L2           : ORIGIN = 0x1c000004, LENGTH = 0x0007fffc
-  L1           : ORIGIN = 0x10000004, LENGTH = 0x0000fffc
+  L2           : ORIGIN = 0x1c000004, LENGTH = 0x000ffffc
+  L1           : ORIGIN = 0x10000004, LENGTH = 0x0001fffc
 }
 
 /*


### PR DESCRIPTION
This branch modifies the linker script for marsellus accordingly with the new memory size.

Moreover it fixes a parameter to use keywords to allocate L1 DATA (to check).