### PR TITLE
:bug: make startup code compliant to cv32e40p

### DIFF
--- a/kernel/crt0.S
+++ b/kernel/crt0.S
@@ -21,12 +21,6 @@
     .global pos_init_entry
 pos_init_entry:
 
-    # Performance counters are active after reset, deactivate them to let the
-    # user control when they should start counting
-    csrw    0x7A1, x0
-
-
-
     # Cluster PEs will also starts here to avoid aligning another entry point
     # Just re-route them to the right entry
 #if defined(ARCHI_HAS_CLUSTER)


### PR DESCRIPTION
- The startup code in crt0.S was compliant to RI5CY specs. The first instruction was:

    // Performance counters are active after reset, deactivate them to let the
    // user control when they should start counting
    **csrw    0x7A1, x0**

- 0x7A1 was the address of the **Performance Counter Mode Register (PCMR)**
- cv32e40p's CSR address mapping is different, now 0x7A1 is the address of **TDATA1**
- cv32e40p's documentation states that "_by default, all available counters are disabled after reset in order to provide the lowest power consumption" (https://core-v-docs-verif-strat.readthedocs.io/projects/cv32e40p_um/en/latest/perf_counters.html)
- Therefore, we can safely delete the instruction in the startup code