### PR TITLE
Revert "Merge pull request #11 from micprog/master"

### DIFF
--- a/rules/pulpos/default_rules.mk
+++ b/rules/pulpos/default_rules.mk
@@ -221,11 +221,8 @@ $(TARGET_BUILD_DIR)/tcl_files:
 $(TARGET_BUILD_DIR)/waves:
 	ln -s $(VSIM_PATH)/waves $@
 
-$(TARGET_BUILD_DIR)/work:
-	ln -s $(VSIM_PATH)/work $@
 
-
-run: $(TARGET_BUILD_DIR)/modelsim.ini  $(TARGET_BUILD_DIR)/boot $(TARGET_BUILD_DIR)/tcl_files $(TARGET_BUILD_DIR)/waves $(TARGET_BUILD_DIR)/work
+run: $(TARGET_BUILD_DIR)/modelsim.ini  $(TARGET_BUILD_DIR)/boot $(TARGET_BUILD_DIR)/tcl_files $(TARGET_BUILD_DIR)/waves
 	$(PULPRT_HOME)/bin/stim_utils.py --binary=$(TARGETS) --vectors=$(TARGET_BUILD_DIR)/vectors/stim.txt
 
 ifdef gui


### PR DESCRIPTION
This reverts commit d898ae342442c68589cbcdae918cafa93600680f, reversing
changes made to b8f77f397fb4e317d2c7e781b58d5c2fddee0737.

The problem is that when you call `make run` twice, then the work target
tries to re-do it since its a broken symlink. Furthermore, it should be
anyway possible to get the bender flow working withouth symlinking the
work directory.