### PR TITLE
Adding malloc implementation

### DIFF
--- a/include/implem/alloc_pool.h
+++ b/include/implem/alloc_pool.h
@@ -21,4 +21,13 @@ void pos_allocs_init();
 
 void alloc_init_l1(int cid);
 
+/*
+ * pos_alloc_user_data and pos_free_user_data will allocate memory in the best
+ * location based on the available hardware. The preferred memories are (in
+ * order): FC_TCDM > L2_private_bank_0 > L2_private_bank_1 > L2_share_banks
+ */
+void *pos_alloc_user_data(int size);
+
+void pos_free_user_data(void *_chunk, int size);
+
 #endif

--- a/kernel/alloc_pool.c
+++ b/kernel/alloc_pool.c
@@ -112,7 +112,7 @@ void pos_free_user_data(void *_chunk, int size)
     unsigned int base = (unsigned int) _chunk;
     if (base < (unsigned int) pos_l2_priv0_base() + pos_l2_priv0_size()) allocator = &pos_alloc_l2[0];
     else if (base < (unsigned int) pos_l2_priv1_base() + pos_l2_priv1_size()) allocator = &pos_alloc_l2[1];
-    else allocator = &pos_alloc_l2[0];
+    else allocator = &pos_alloc_l2[2];
     pos_free(allocator, _chunk, size);
 #else
     pos_free(&pos_alloc_l2[0]);

--- a/lib/libc/minimal/io.c
+++ b/lib/libc/minimal/io.c
@@ -398,3 +398,24 @@ int pos_io_stop()
 
   return 0;
 }
+
+
+void *malloc(size_t size)
+{
+    // We will store the size of the chunk at the beginning of the allocated memory.
+    void *ptr = pos_alloc_user_data(size + sizeof(uint32_t));
+    if (ptr == NULL) return NULL;
+    
+    *((uint32_t *)ptr) = size + sizeof(uint32_t);
+    void *user_ptr = (void *)(((uint32_t) ptr) + 1);
+    
+    return user_ptr;
+}
+
+
+void free(void *ptr)
+{
+    void *alloc_ptr = (void *)(((uint32_t *) ptr) - 1);
+    uint32_t size = *((uint32_t *) alloc_ptr);
+    pos_free_user_data(alloc_ptr, size);
+}


### PR DESCRIPTION
# Reason for the Pull Request

See issue #15, `malloc` and `free` are declared in the [stdlib header of the pulp-runtime](https://github.com/pulp-platform/pulp-runtime/blob/master/lib/libc/minimal/include/stdlib.h) but are not actually implemented as of commit 252cecb.

# Changes introduced by the Pull Request

This pull request introduces 3 main changes in the codebase:

1. In [alloc_pool.h](https://github.com/pulp-platform/pulp-runtime/blob/master/include/implem/alloc_pool.h), two functions were added: `pos_alloc_user_data` and `pos_free_user_data`. These functions are used to hide from the user the location where the data is allocated, which may change with the hardware (as was the case in [pulp-rt](https://github.com/pulp-platform/pulp-rt), see [rt_alloc](https://github.com/pulp-platform/pulp-rt/blob/master/kernel/alloc.c)). That way, the `pos_alloc_t` structs are only visible within [alloc_pool.c](https://github.com/pulp-platform/pulp-runtime/blob/master/kernel/alloc_pool.c) and not exposed to the end user.

2. In [alloc_pool.c](https://github.com/pulp-platform/pulp-runtime/blob/master/kernel/alloc_pool.c), I added the implementations for `pos_alloc_user_data` and `pos_free_user_data`. The preferred locations to put the data are the same as in [rt_alloc](https://github.com/pulp-platform/pulp-rt/blob/master/kernel/alloc.c).

3. In [io.c](https://github.com/pulp-platform/pulp-runtime/blob/master/lib/libc/minimal/io.c), I added the implementation for `malloc` and `free`. The implementation is similar to that used in [the io.c of pulp-rt](https://github.com/pulp-platform/pulp-rt/blob/master/libs/io/io.c) in that the size of the allocated chunk is stored before the pointer given to the user.

# Additional Notes

I tried to keep the same style as the rest of the codebase so that the code would blend in well, and I also reused names from [pulp-rt](https://github.com/pulp-platform/pulp-rt).

I haven't thoroughly tested the code yet, but I should be able to during the week. I can post a small update then if the PR hasn't been merged yet.

Finally, the internal `pos_alloc` in [alloc.c](https://github.com/pulp-platform/pulp-runtime/blob/master/kernel/alloc.c) uses `int` for the size, while `malloc` stores it as a `uint32_t`. I kept that from the original codebase to avoid introducing many changes at once, but it might cause bugs in edge cases where a size >2GB is allocated at once.