### PR TITLE
Fix control-pulp compilation flags

### DIFF
--- a/rules/pulpos/targets/control-pulp.mk
+++ b/rules/pulpos/targets/control-pulp.mk
@@ -5,9 +5,9 @@ endif
 # we need at least pulp-gcc v2.1.2
 PULP_LDFLAGS      +=
 PULP_CFLAGS       +=  -D__riscv__
-PULP_ARCH_CFLAGS ?=  -march=rv32imcxcorev -mno-pulp-hwloop
-PULP_ARCH_LDFLAGS ?=  -march=rv32imcxcorev -mno-pulp-hwloop
-PULP_ARCH_OBJDFLAGS ?= -Mmarch=rv32imcxcorev -mno-pulp-hwloop
+PULP_ARCH_CFLAGS ?=  -march=rv32imcxgap9 -mnohwloop
+PULP_ARCH_LDFLAGS ?=  -march=rv32imcxgap9 -mnohwloop
+PULP_ARCH_OBJDFLAGS ?= -Mmarch=rv32imcxgap9 -mnohwloop
 
 PULP_CFLAGS    += -fdata-sections -ffunction-sections \
 	-include chips/pulp/config.h -I$(PULPRT_HOME)/include/chips/control-pulp


### PR DESCRIPTION
# **Overview**

Support for `control_pulp` as a separate target has been provided in #21
This PR resets the compilation flags to the `v1.0.16` release of PULP GCC. Support for cv32e40p and the new compiler built on top of GCC 9.2 will be provided in [control_pulp_dev](https://github.com/pulp-platform/pulp-runtime/tree/control_pulp_dev)

# **Checklist**
- [x]  Fix control-pulp compilation flags

