### PR TITLE
vsim compatibility updates

### DIFF
--- a/rules/pulpos/default_rules.mk
+++ b/rules/pulpos/default_rules.mk
@@ -257,6 +257,13 @@ ifndef VSIM_PATH
 endif
 	ln -s $(VSIM_PATH)/modelsim.ini $@
 
+$(TARGET_BUILD_DIR)/work:
+ifndef VSIM_PATH
+	$(error "VSIM_PATH is undefined. Either call \
+	'source $$YOUR_HW_DIR/setup/vsim.sh' or set it manually.")
+endif
+	ln -s $(VSIM_PATH)/work $@
+
 $(TARGET_BUILD_DIR)/boot:
 ifndef VSIM_PATH
 	$(error "VSIM_PATH is undefined. Either call \
@@ -285,7 +292,7 @@ $(TARGET_BUILD_DIR)/fs:
 	mkdir -p $@
 
 
-run: $(TARGET_BUILD_DIR)/modelsim.ini  $(TARGET_BUILD_DIR)/boot $(TARGET_BUILD_DIR)/tcl_files $(TARGET_BUILD_DIR)/stdout $(TARGET_BUILD_DIR)/fs $(TARGET_BUILD_DIR)/waves
+run: $(TARGET_BUILD_DIR)/modelsim.ini $(TARGET_BUILD_DIR)/work  $(TARGET_BUILD_DIR)/boot $(TARGET_BUILD_DIR)/tcl_files $(TARGET_BUILD_DIR)/stdout $(TARGET_BUILD_DIR)/fs $(TARGET_BUILD_DIR)/waves
 	$(PULPRT_HOME)/bin/stim_utils.py --binary=$(TARGETS) --vectors=$(TARGET_BUILD_DIR)/vectors/stim.txt
 	$(PULPRT_HOME)/bin/plp_mkflash  --flash-boot-binary=$(TARGETS)  --stimuli=$(TARGET_BUILD_DIR)/vectors/qspi_stim.slm --flash-type=spi --qpi
 	$(PULPRT_HOME)/bin/slm_hyper.py  --input=$(TARGET_BUILD_DIR)/vectors/qspi_stim.slm  --output=$(TARGET_BUILD_DIR)/vectors/hyper_stim.slm

--- a/rules/pulpos/default_rules.mk
+++ b/rules/pulpos/default_rules.mk
@@ -8,6 +8,7 @@ override runner_args += --config-opt=**/runner/verbose=true
 endif
 
 platform ?= rtl
+VSIM ?= vsim
 
 
 ifdef PULP_RUNTIME_GCC_TOOLCHAIN
@@ -294,9 +295,9 @@ ifndef VSIM_PATH
 endif
 
 ifdef gui
-	cd $(TARGET_BUILD_DIR) && export VSIM_RUNNER_FLAGS='$(vsim_flags)' && export VOPT_ACC_ENA="YES" && vsim -64 -do 'source $(VSIM_PATH)/tcl_files/config/run_and_exit.tcl' -do 'source $(VSIM_PATH)/tcl_files/run.tcl; '
+	cd $(TARGET_BUILD_DIR) && export VSIM_RUNNER_FLAGS='$(vsim_flags)' && export VOPT_ACC_ENA="YES" && $(VSIM) -64 -do 'source $(VSIM_PATH)/tcl_files/config/run_and_exit.tcl' -do 'source $(VSIM_PATH)/tcl_files/run.tcl; '
 else
-	cd $(TARGET_BUILD_DIR) && export VSIM_RUNNER_FLAGS='$(vsim_flags)' && vsim -64 -c -do 'source $(VSIM_PATH)/tcl_files/config/run_and_exit.tcl' -do 'source $(VSIM_PATH)/tcl_files/run.tcl; run_and_exit;'
+	cd $(TARGET_BUILD_DIR) && export VSIM_RUNNER_FLAGS='$(vsim_flags)' && $(VSIM) -64 -c -do 'source $(VSIM_PATH)/tcl_files/config/run_and_exit.tcl' -do 'source $(VSIM_PATH)/tcl_files/run.tcl; run_and_exit;'
 endif
 
 endif


### PR DESCRIPTION
- Allow `$VSIM` environment variable to override the `vsim` command when calling the simulator
- Symlink `work` directory into the build folder