### PR TITLE
Add PULPissimo/CV32E40P support

### DIFF
--- a/configs/pulpissimo_cv32.sh
+++ b/configs/pulpissimo_cv32.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+export PULPRT_TARGET=pulpissimo
+export PULPRUN_TARGET=pulpissimo
+export USE_CV32E40P=1
+# use plusarg to pass simulation boot parameters instead of floating parameters
+export CONFIG_PLUSARG_SIM=1
+unset CONFIG_USE_ZFINX
+
+if [  -n "${ZSH_VERSION:-}" ]; then
+        DIR="$(readlink -f -- "${(%):-%x}")"
+        scriptDir="$(dirname $DIR)"
+else
+
+    scriptDir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+fi
+
+source $scriptDir/common.sh

--- a/configs/pulpissimo_cv32_zfinx.sh
+++ b/configs/pulpissimo_cv32_zfinx.sh
@@ -5,6 +5,7 @@ export PULPRUN_TARGET=pulpissimo
 export USE_CV32E40P=1
 # use plusarg to pass simulation boot parameters instead of floating parameters
 export CONFIG_PLUSARG_SIM=1
+export CONFIG_USE_ZFINX=1
 
 if [  -n "${ZSH_VERSION:-}" ]; then
         DIR="$(readlink -f -- "${(%):-%x}")"

--- a/configs/pulpissimo_cv32e40p.sh
+++ b/configs/pulpissimo_cv32e40p.sh
@@ -3,6 +3,8 @@
 export PULPRT_TARGET=pulpissimo
 export PULPRUN_TARGET=pulpissimo
 export USE_CV32E40P=1
+# use plusarg to pass simulation boot parameters instead of floating parameters
+export CONFIG_PLUSARG_SIM=1
 
 if [  -n "${ZSH_VERSION:-}" ]; then
         DIR="$(readlink -f -- "${(%):-%x}")"

--- a/rules/pulpos/default_rules.mk
+++ b/rules/pulpos/default_rules.mk
@@ -151,7 +151,29 @@ endif
 #
 # VSIM Flags
 #
-vsim_flags ?= +ENTRY_POINT=0x1c008080 -dpicpppath /usr/bin/g++ -permit_unmatched_virtual_intf -gBAUDRATE=115200
+vsim_flags ?= +ENTRY_POINT=0x1c008080 -permit_unmatched_virtual_intf -gBAUDRATE=115200
+
+ifdef CONFIG_PLUSARG_SIM
+
+ifdef bootmode
+ifeq ($(bootmode), spi)
+vsim_flags += +bootmode=spi_flash
+else ifeq ($(bootmode), hyperflash)
+vsim_flags += +bootmode=hyper_flash
+else ifeq ($(bootmode), fast_debug)
+vsim_flags += +bootmode=fast_debug_preload
+else ifeq ($(bootmode), jtag)
+vsim_flags += +bootmode=jtag
+else
+$(error Illegal value supplied for bootmode. Legal values are 'spi', 'hyperflash', 'fast_debug' and 'jtag')
+endif
+else
+# default bootmode
+vsim_flags += +bootmode=jtag
+endif
+
+else
+
 ifdef bootmode
 ifeq ($(bootmode), spi)
 vsim_flags += -gSTIM_FROM=SPI_FLASH -gLOAD_L2=STANDALONE -gUSE_S25FS256S_MODEL=1
@@ -173,6 +195,9 @@ endif
 else
 vsim_flags += -gLOAD_L2=JTAG
 endif
+endif
+
+
 ifdef vsim_additional_flags
 vsim_flags += $(vsim_additional_flags)
 endif

--- a/rules/pulpos/default_rules.mk
+++ b/rules/pulpos/default_rules.mk
@@ -1,5 +1,6 @@
 TARGET_BUILD_DIR = $(CURDIR)/build$(build_dir_ext)
-ifndef VERBOSE
+
+ifdef QUIET
 V = @
 endif
 

--- a/rules/pulpos/targets/pulpissimo.mk
+++ b/rules/pulpos/targets/pulpissimo.mk
@@ -7,9 +7,14 @@ PULP_ARCH_OBJDFLAGS ?= -Mmarch=rv32imc
 else ifdef USE_CV32E40P
 PULP_LDFLAGS +=
 PULP_CFLAGS += -D__cv32e40p__ -U__riscv__ -UARCHI_CORE_HAS_PULPV2
-PULP_ARCH_CFLAGS ?=  -march=rv32imcxgap9
-PULP_ARCH_LDFLAGS ?=  -march=rv32imcxgap9
-PULP_ARCH_OBJDFLAGS ?= -Mmarch=rv32imcxgap9
+ifdef CONFIG_USE_ZFINX
+PULP_ARCH_CFLAGS ?=  -march=rv32imc_zfinx_xcorev -mno-pulp-hwloop
+PULP_ARCH_LDFLAGS ?=  -march=rv32imc_zfinx_xcorev -mno-pulp-hwloop
+else
+PULP_ARCH_CFLAGS ?=  -march=rv32imfc_xcorev -mno-pulp-hwloop
+PULP_ARCH_LDFLAGS ?=  -march=rv32imfc_xcorev -mno-pulp-hwloop
+endif
+PULP_ARCH_OBJDFLAGS ?=
 else
 PULP_LDFLAGS      +=
 PULP_CFLAGS       +=  -D__riscv__


### PR DESCRIPTION
* Needs testbench changes: we now pass arguments via plusargs
* Add zfinx and non zfinx versions
* Use gcc 9.2.0