### PR TITLE
Fix missing argument `Loader` in `bwruntests.py`

### DIFF
--- a/scripts/bwruntests.py
+++ b/scripts/bwruntests.py
@@ -246,7 +246,7 @@ the pyyaml library which is not installed.""",
                   file=sys.stderr)
             exit(1)
         with open(args.test_file) as f:
-            testyaml = yaml.load(f)
+            testyaml = yaml.load(f, Loader=yaml.Loader)
             for testsetname, testv in testyaml.items():
                 for testname, insn in testv.items():
                     cmd = shlex.split(insn['command'])


### PR DESCRIPTION
Newer version of `pyyaml` requires an additional argument `Loader` in the function `load`. For further details see [this related stackoverflow question](https://stackoverflow.com/questions/69564817/typeerror-load-missing-1-required-positional-argument-loader-in-google-col). This fix could be relevant also for other branches.