### PR TITLE
Small quality-of-life fixes

### DIFF
--- a/rules/pulpos/default_rules.mk
+++ b/rules/pulpos/default_rules.mk
@@ -286,35 +286,35 @@ ifndef VSIM_PATH
 	$(error "VSIM_PATH is undefined. Either call \
 	'source $$YOUR_HW_DIR/setup/vsim.sh' or set it manually.")
 endif
-	ln -s $(VSIM_PATH)/modelsim.ini $@
+	ln -sfn $(VSIM_PATH)/modelsim.ini $@
 
 $(TARGET_BUILD_DIR)/work:
 ifndef VSIM_PATH
 	$(error "VSIM_PATH is undefined. Either call \
 	'source $$YOUR_HW_DIR/setup/vsim.sh' or set it manually.")
 endif
-	ln -s $(VSIM_PATH)/work $@
+	ln -sfn $(VSIM_PATH)/work $@
 
 $(TARGET_BUILD_DIR)/boot:
 ifndef VSIM_PATH
 	$(error "VSIM_PATH is undefined. Either call \
 	'source $$YOUR_HW_DIR/setup/vsim.sh' or set it manually.")
 endif
-	ln -s $(VSIM_PATH)/boot $@
+	ln -sfn $(VSIM_PATH)/boot $@
 
 $(TARGET_BUILD_DIR)/tcl_files:
 ifndef VSIM_PATH
 	$(error "VSIM_PATH is undefined. Either call \
 	'source $$YOUR_HW_DIR/setup/vsim.sh' or set it manually.")
 endif
-	ln -s $(VSIM_PATH)/tcl_files $@
+	ln -sfn $(VSIM_PATH)/tcl_files $@
 
 $(TARGET_BUILD_DIR)/waves:
 ifndef VSIM_PATH
 	$(error "VSIM_PATH is undefined. Either call \
 	'source $$YOUR_HW_DIR/setup/vsim.sh' or set it manually.")
 endif
-	ln -s $(VSIM_PATH)/waves $@
+	ln -sfn $(VSIM_PATH)/waves $@
 
 $(TARGET_BUILD_DIR)/stdout:
 	mkdir -p $@

--- a/rules/pulpos/targets/carfield-cluster.mk
+++ b/rules/pulpos/targets/carfield-cluster.mk
@@ -1,4 +1,10 @@
+HOSTNAME := $(shell hostname)
+ETH_HOST = $(shell echo $(HOSTNAME) | grep -q "\.ee\.ethz\.ch$$" && echo 1 || echo 0)
+ifeq (ETH_HOST,1)
 QUESTA ?= questa-2022.3
+else
+QUESTA ?= 
+endif
 ifdef USE_IBEX
 PULP_LDFLAGS      +=
 PULP_CFLAGS       +=  -D__ibex__ -U__riscv__ -UARCHI_CORE_HAS_PULPV2 -DRV_ISA_RV32
@@ -73,5 +79,5 @@ ifndef gui
 vsim-flags = -c
 endif
 
-run:
-	$(QUESTA) vsim $(vsim-flags) -do "set  VSIM_PATH $(VSIM_PATH); source $(VSIM_PATH)/scripts/start.tcl"
+run: $(TARGETS)
+	cd $(TARGET_BUILD_DIR); $(QUESTA) vsim $(vsim-flags) -do "set  VSIM_PATH $(VSIM_PATH); source $(VSIM_PATH)/scripts/start.tcl"


### PR DESCRIPTION
1) enable compilation without cleaning by overwriting the (anyways broken!)
   modelsim.ini, etc. files on symlink creation
2) work out-of-the-box on non-ETH machines by not defining the QUESTA
   env var
3) make run dependent on $(TARGETS) being built