### PR TITLE
rules: Add threadx support

### DIFF
--- a/rules/pulpos/targets/safety-island.mk
+++ b/rules/pulpos/targets/safety-island.mk
@@ -32,4 +32,15 @@ ifeq '$(platform)' 'fpga'
 CONFIG_IO_UART=1
 endif
 
+###########
+# Threadx #
+###########
+
+TX_DIR := $(PULPRT_HOME)/threadx
+-include $(PULPRT_HOME)/threadx/threadx.mk
+TX_INCS += -I$(TX_DIR)/ports/safety_island/gnu/inc
+PULP_APP_CFLAGS  += -DTEST_STACK_SIZE_PRINTF=4096
+PULP_APP_CFLAGS  += $(TX_INCS)
+PULP_LDFLAGS += $(TX_SW_LIBS)
+
 include $(PULPRT_HOME)/rules/pulpos/default_rules.mk


### PR DESCRIPTION
Should not break existing bare-metal pulp runtime since the makefrag is included only if it exists (`-include`)